### PR TITLE
Fix exercise 5.11

### DIFF
--- a/lectures/lectures.tex
+++ b/lectures/lectures.tex
@@ -554,7 +554,7 @@ Exercises
     \item Estimate $\sum_{k\ge 0} e^{-k/n}$ with abs. error $O(n^{-1})$. [K9.7] \ans{$n+1/2+O(n^{-1})$}
     \item Estimate $H_n^5/\ln (n + 5)$ with abs. error $O(n^{-2})$. \ans{$2+{\gamma\over \ln n}-{6\over n\ln n}-{3\gamma\over n\ln^2 n}+O(n^{-2})$}
     \item Estimate $2n\choose n$ with relative error $O(n^{-2})$. [A1] \ans{${2^{2n}\over \sqrt{\pi n}}\left(1-{1\over 8n}+O(n^{-2})\right)$}
-    \item Estimate $2n+1\choose n$ with relative error $O(n^{-2})$. [A2] \ans{${2^{2n+1}\over \sqrt{\pi n}}\left(1-{1\over 5n}+O(n^{-2})\right)$}
+    \item Estimate $2n+1\choose n$ with relative error $O(n^{-2})$. [A2] \ans{${2^{2n+1}\over \sqrt{\pi n}}\left(1-{5\over 8n}+O(n^{-2})\right)$}
     \item Compare $(n!)!$ with $((n-1)!)!\cdot (n-1)!^{n!}$. [K9.2c] (Homework if not enough time is left.)
 \end{enumerate}
 


### PR DESCRIPTION
The error seems to originate from `1/4n + 1/n = 1/5n` (should be `5/4n`).

https://www.wolframalpha.com/input?i=lim+n+to+inf+choose%282n%2B1%2C+n%29%2F%282%5E%282n%2B1%29%2Fsqrt%28pi+n%29%29